### PR TITLE
Add support for GetByPrefix

### DIFF
--- a/prefixmap.go
+++ b/prefixmap.go
@@ -249,6 +249,27 @@ func (m *PrefixMap) Get(key string) []interface{} {
     return retrievedNode.data
 }
 
+// GetByPrefix returns a flattened collection of values
+// associated with the given prefix key
+func (m *PrefixMap) GetByPrefix(key string) []interface{} {
+    mNode := (*Node)(m)
+    retrievedNode, _ := mNode.nodeForKey(key, false)
+    
+    // now, fetching all the values (DFS)
+    stack := stackgo.NewStack()
+    values := []interface{}{}
+    stack.Push(retrievedNode)
+    for stack.Size() > 0 {
+        node := stack.Pop().(*Node)
+        values = append(values, node.data...)
+        for _, c := range node.Children {
+            stack.Push(c)
+        }
+    }
+    
+    return values
+}
+
 // ContainsPrefix checks if the given prefix is present as key in the map
 func (m *PrefixMap) ContainsPrefix(key string) bool {
     mNode := (*Node)(m)

--- a/prefixmap_test.go
+++ b/prefixmap_test.go
@@ -140,6 +140,32 @@ func TestPrefixAsKey(t *testing.T) {
     }
 }
 
+func TestGetByPrefix(t *testing.T) {
+    testCases := []struct {
+        keys []interface{}
+        prefix string
+        expectedValues []interface{}
+    }{
+        {
+            keys: []interface{}{ "prefix1", "prefix2", "prefix3" },
+            prefix: "prefix",
+            expectedValues: []interface{}{"prefix3", "prefix2", "prefix1"},
+        },
+    }
+    
+    for _, tc := range testCases {
+        m := New()
+        for _, k := range tc.keys {
+            m.Insert(k.(string), k)
+        }
+        data := m.GetByPrefix(tc.prefix)
+        
+        if testEq(tc.expectedValues, data) != true {
+            t.Errorf("Unexpected value for prefix '%s', expected: %v, got: %v", tc.prefix, tc.expectedValues, data)
+        }
+    }
+}
+
 func TestLcp(t *testing.T) {
     lcpTestCases := []struct {
         source, destination, expected string


### PR DESCRIPTION
GetByPrefix allows the retrieval of values in the map
specifying a common prefix for the associated key(s)
